### PR TITLE
Need to specify the rev for micro rdk by tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 rust-version = "1.83"
 
 [dependencies]
-micro-rdk = { git = "https://github.com/viamrobotics/micro-rdk.git", features = ["esp32", "binstart"], version = "0.4.1-rc10" }
+micro-rdk = { git = "https://github.com/viamrobotics/micro-rdk.git", features = ["esp32", "binstart"], version = "0.4.1-rc10", rev = "v0.4.1-rc10" }
 
 [package.metadata.com.viam]
 module = true


### PR DESCRIPTION
@stevebriskin - My PR last week was incomplete. When specifying dependencies as git repos, only `rev` actually has effect.